### PR TITLE
Change rest_transport_uri value to http://graylog:12900/

### DIFF
--- a/graylog/server.conf
+++ b/graylog/server.conf
@@ -18,7 +18,7 @@ root_email = "admin@yourdomain.com"
 
 plugin_dir = plugin
 rest_listen_uri = http://0.0.0.0:12900/
-rest_transport_uri= http://192.168.99.100:12900/
+rest_transport_uri= http://graylog:12900/
 rest_enable_cors = true
 rotation_strategy = count
 


### PR DESCRIPTION
Problem: after running docker-compose, the log transfer does not work out of the box. 
Solution: rest_transport_uri has a fixed IP address. This IP address is changed to "graylog" because it references the current public ip address of the graylog server docker container. 

Should solve issue #4 